### PR TITLE
Vectorise per-elevation HRIR EQ and high-pass over azimuth/channel

### DIFF
--- a/ash_toolset/hrir_processing.py
+++ b/ash_toolset/hrir_processing.py
@@ -1269,12 +1269,15 @@ def apply_eq_to_hrirs(hrir_out, elev, total_samples_hrir, total_azim_hrir, hrir_
         total_azim_hrir (int): Total number of azimuths
         hrir_df_inv_fir (np.ndarray): EQ filter to apply
     """
-    for azim in range(total_azim_hrir):
-        for chan in range(CN.TOTAL_CHAN_BRIR):
-            # Convolve HRIR with EQ filter
-            hrir_eq = sp.signal.convolve(hrir_out[elev, azim, chan, :], hrir_df_inv_fir, mode='full')
-            # Truncate or pad to original length
-            hrir_out[elev, azim, chan, :] = hrir_eq[:total_samples_hrir]
+    # Only the leading total_samples_hrir taps of the filter can contribute to the
+    # first total_samples_hrir output samples, which is all that is kept below.
+    eq_fir = hrir_df_inv_fir[:total_samples_hrir]
+
+    # Convolve all azimuths and channels for this elevation in one pass
+    hrir_block = hrir_out[elev, :total_azim_hrir, :CN.TOTAL_CHAN_BRIR, :]
+    hrir_eq = sp.signal.fftconvolve(hrir_block, eq_fir[None, None, :], mode='full', axes=-1)
+    # Truncate or pad to original length
+    hrir_out[elev, :total_azim_hrir, :CN.TOTAL_CHAN_BRIR, :] = hrir_eq[..., :total_samples_hrir]
 
 
 
@@ -1290,12 +1293,12 @@ def apply_hp_to_hrirs(hrir_out, elev, total_samples_hrir, total_azim_hrir, hp_so
         total_azim_hrir (int): Total number of azimuths
         hp_sos (np.ndarray): SOS filter coefficients for high-pass filter
     """
-    for azim in range(total_azim_hrir):
-        for chan in range(CN.TOTAL_CHAN_BRIR):
-            # Apply high-pass filter
-            hrir_filtered = hf.apply_sos_filter(hrir_out[elev, azim, chan, :], hp_sos, filtfilt=filtfilt)
-            # Truncate or pad to original length
-            hrir_out[elev, azim, chan, :] = hrir_filtered[:total_samples_hrir]
+    # Filter all azimuths and channels for this elevation in one pass
+    hrir_block = hrir_out[elev, :total_azim_hrir, :CN.TOTAL_CHAN_BRIR, :]
+    # Apply high-pass filter
+    hrir_filtered = hf.apply_sos_filter(hrir_block, hp_sos, filtfilt=filtfilt, axis=-1)
+    # Truncate or pad to original length
+    hrir_out[elev, :total_azim_hrir, :CN.TOTAL_CHAN_BRIR, :] = hrir_filtered[..., :total_samples_hrir]
 
 
 


### PR DESCRIPTION
apply_eq_to_hrirs and apply_hp_to_hrirs each looped over azimuth and channel, calling scipy.signal.convolve / apply_sos_filter once per 256-sample signal. At that length the per-call overhead dominates the arithmetic, so both now process the whole (azimuth, channel, samples) block for the elevation in a single call.

apply_hp_to_hrirs: apply_sos_filter already accepts an axis argument, so the loop was redundant. Output is bit-identical (np.array_equal).

apply_eq_to_hrirs: uses fftconvolve along the sample axis. It also truncates the EQ filter to total_samples_hrir taps, since output sample n < total_samples_hrir is sum(fir[k] * hrir[n-k]) for k <= n and can never depend on later taps; with a 1024-tap filter and 256-sample HRIRs 768 taps were computed and discarded. Mathematically equivalent; the residual difference is floating-point summation order, measured at up to 6.9e-17 (~306 dB below peak, a few ULP).

Measured on the HRIR datasets in data/interim/hrir (float64, filter parameters as used in production: Butterworth order 9, 120 Hz, filtfilt=False, 1024-tap EQ FIR):

  THK KU-100  25x72    eq 0.265s -> 0.023s (11.4x)   hp 0.121s -> 0.012s (10.3x)
  THK KU-100  51x180   eq 1.323s -> 0.133s ( 9.9x)   hp 0.598s -> 0.052s (11.5x)
  TU FABIAN   25x72    eq 0.267s -> 0.021s (12.7x)   hp 0.123s -> 0.012s (10.5x)
  SADIE KEMAR 25x72    eq 0.256s -> 0.020s (12.6x)   hp 0.113s -> 0.011s (10.3x)

Verified on a second machine with a different scipy version: speedups ranged from 7x to 12.7x and apply_hp_to_hrirs was bit-identical in both runs.

Of the apply_eq_to_hrirs speedup, roughly 2.2x comes from batching and the remainder from the filter truncation.