### PR TITLE
Fix unsatisfiable scipy/numpy pin in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ platformdirs==4.5.0
 rapidfuzz==3.9.3
 pyfar==0.6.5
 Requests==2.32.5
-scipy==1.11.4
+scipy>=1.15.0
 sofar==1.1.3
 SOFASonix==1.0.7
 sounddevice==0.5.3


### PR DESCRIPTION
Fix unsatisfiable scipy/numpy pin in requirements.txt

pip install -r requirements.txt fails with ResolutionImpossible:
scipy 1.11.4 depends on numpy<1.28.0, but numpy==2.3.4 is pinned.
The conflict is independent of Python version and platform, so
anyone installing from source is blocked at the first step.

Raised to a floor rather than a new pin, since numpy is already
pinned exactly. 1.15.0 is the true minimum: scipy 1.14.1 and
earlier declare numpy<2.3, which excludes numpy==2.3.4.